### PR TITLE
[MP-380] Remove deprecation warning as we are now maintaining this step for better or for worse

### DIFF
--- a/step.rb
+++ b/step.rb
@@ -6,9 +6,6 @@ begin
 	team_id = ENV['itunes_connect_team_id']
 	app_id_prefix = ENV['app_id_prefix']
 
-	puts "\e[31mThis step is deprecated, please use export-xcarchive step instead\e[0m"
-	puts "\e[31mWill be removed by: 2017.10.01\e[0m"
-
 	puts 'Configs:'
 	puts "  * ipa_path: #{ipa_path}"
 	puts "  * distribution_type: #{distribution_type}"


### PR DESCRIPTION
This is a trivial change but I kicked off a resign job at https://app.bitrise.io/build/882d87b6c57cf127#?tab=log just to verify no issues arise